### PR TITLE
Adding setHeaders method

### DIFF
--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -63,8 +63,23 @@
       return null;
     }
 
-    function setHeaders(headers){
-        jsonrpcConfig.headers= angular.extend(jsonrpcConfig.headers, headers);
+    function setHeaders(headers, serverName) {
+      if (typeof serverName != 'undefined') {
+        for (var i = 0; i < jsonrpcConfig.servers.length; i++){
+          if (jsonrpcConfig.servers[i].name === serverName) {
+            Object.keys(headers).forEach(function (key) {
+              jsonrpcConfig.servers[i].headers[key] = headers[key];
+            });
+          }
+        }
+      }
+      else {
+        for (var j = 0; j < jsonrpcConfig.servers.length; j++) {
+          Object.keys(headers).forEach(function (key) {
+            jsonrpcConfig.servers[j].headers[key] = headers[key];
+          });
+        }
+      }
     }
 
     function request(arg1, arg2, arg3) {
@@ -105,7 +120,7 @@
        data: inputData
       };
 
-      req.headers = angular.extend(req.headers, jsonrpcConfig.headers);
+      req.headers = angular.extend(req.headers, backend.headers);
 
       var promise = $http(req);
 
@@ -179,8 +194,7 @@
   function jsonrpcConfig() {
     var config = {
       servers: [],
-      returnHttpPromise: false,
-      headers: {}
+      returnHttpPromise: false
     };
 
     this.set = function(args) {
@@ -188,7 +202,7 @@
         throw new Error('Argument of "set" must be an object.');
       }
 
-      var allowedKeys = ['url', 'servers', 'returnHttpPromise', 'headers'];
+      var allowedKeys = ['url', 'servers', 'returnHttpPromise'];
       var keys = Object.keys(args);
       keys.forEach(function(key) {
         if (allowedKeys.indexOf(key) < 0) {

--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -35,6 +35,7 @@
   function jsonrpc($q, $http, jsonrpcConfig) {
     return {
       request              : request,
+      setHeaders           : setHeaders,
       ERROR_TYPE_SERVER    : ERROR_TYPE_SERVER,
       ERROR_TYPE_TRANSPORT : ERROR_TYPE_TRANSPORT,
       ERROR_TYPE_CONFIG    : ERROR_TYPE_CONFIG,
@@ -60,6 +61,10 @@
         }
       }
       return null;
+    }
+
+    function setHeaders(headers){
+        jsonrpcConfig.headers= angular.extend(jsonrpcConfig.headers, headers);
     }
 
     function request(arg1, arg2, arg3) {
@@ -100,6 +105,8 @@
        data: inputData
       };
 
+      req.headers = angular.extend(req.headers, jsonrpcConfig.headers);
+
       var promise = $http(req);
 
       if (jsonrpcConfig.returnHttpPromise) {
@@ -110,9 +117,9 @@
         // 1. Call was a success.
         // 2. Call was received by the server. Server returned an error.
         // 3. Call did not arrive at the server.
-        // 
+        //
         // 2 is a JsonRpcServerError, 3 is a JsonRpcTransportError.
-        // 
+        //
         // We are assuming that the server can use either 200 or 500 as
         // http return code in situation 2. That depends on the server
         // implementation and is not determined by the JSON-RPC spec.
@@ -165,13 +172,15 @@
       }
 
       return deferred.promise;
-    }    
+      
+    }
   }
 
   function jsonrpcConfig() {
     var config = {
       servers: [],
-      returnHttpPromise: false
+      returnHttpPromise: false,
+      headers: {}
     };
 
     this.set = function(args) {
@@ -179,7 +188,7 @@
         throw new Error('Argument of "set" must be an object.');
       }
 
-      var allowedKeys = ['url', 'servers', 'returnHttpPromise'];
+      var allowedKeys = ['url', 'servers', 'returnHttpPromise', 'headers'];
       var keys = Object.keys(args);
       keys.forEach(function(key) {
         if (allowedKeys.indexOf(key) < 0) {

--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -64,19 +64,24 @@
     }
 
     function setHeaders(headers, serverName) {
-      if (typeof serverName != 'undefined') {
-        for (var i = 0; i < jsonrpcConfig.servers.length; i++){
+      for (var i = 0; i < jsonrpcConfig.servers.length; i++) {
+        if (typeof serverName != 'undefined') {
           if (jsonrpcConfig.servers[i].name === serverName) {
+            if (typeof jsonrpcConfig.servers[i].headers === 'undefined') {
+              jsonrpcConfig.servers[i].headers = {};
+            }
             Object.keys(headers).forEach(function (key) {
               jsonrpcConfig.servers[i].headers[key] = headers[key];
             });
+            return;
           }
         }
-      }
-      else {
-        for (var j = 0; j < jsonrpcConfig.servers.length; j++) {
+        else {
+          if (typeof jsonrpcConfig.servers[i].headers === 'undefined') {
+            jsonrpcConfig.servers[i].headers = {};
+          }
           Object.keys(headers).forEach(function (key) {
-            jsonrpcConfig.servers[j].headers[key] = headers[key];
+            jsonrpcConfig.servers[i].headers[key] = headers[key];
           });
         }
       }
@@ -213,7 +218,8 @@
         if (key === 'url') {
           config.servers = [{
             name: 'main',
-            url: args[key]
+            url: args[key],
+            headers:{}
           }];
         }
         else {

--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -67,9 +67,6 @@
       for (var i = 0; i < jsonrpcConfig.servers.length; i++) {
         if (typeof serverName != 'undefined') {
           if (jsonrpcConfig.servers[i].name === serverName) {
-            if (typeof jsonrpcConfig.servers[i].headers === 'undefined') {
-              jsonrpcConfig.servers[i].headers = {};
-            }
             Object.keys(headers).forEach(function (key) {
               jsonrpcConfig.servers[i].headers[key] = headers[key];
             });
@@ -77,9 +74,6 @@
           }
         }
         else {
-          if (typeof jsonrpcConfig.servers[i].headers === 'undefined') {
-            jsonrpcConfig.servers[i].headers = {};
-          }
           Object.keys(headers).forEach(function (key) {
             jsonrpcConfig.servers[i].headers[key] = headers[key];
           });
@@ -214,7 +208,6 @@
           throw new JsonRpcConfigError('Invalid configuration key "' + key + "'. Allowed keys are: " +
             allowedKeys.join(', '));
         }
-        
         if (key === 'url') {
           config.servers = [{
             name: 'main',
@@ -225,7 +218,13 @@
         else {
           config[key] = args[key];
         }
+
       });
+      for (var i = 0; i < config.servers.length; i++) {
+        if (typeof config.servers[i].headers === 'undefined') {
+          config.servers[i].headers = {};
+        }
+      }
     };
 
     this.$get = function() {


### PR DESCRIPTION
Allows to set custom http headers via: 

```
jsonrpc.setHeaders({'X-Auth':123});
```

and/or

```
jsonrpcConfigProvider.set(headers:{'xy':123,'z':45});
```
