### PR TITLE
Joost/feature/set headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The client is configured in the Angular configuration phase via the `jsonrpcConf
 # Getting started
 
 ```
-// For a single JSON-RPC server
+// For a single JSON-RPC server:
+// (this way of configuring is simple and only recommended for the most
+// basic usage)
 angular
     .module('MyApp', ['angular-jsonrpc-client'])
     .config(function(jsonrpcConfigProvider) {
@@ -91,7 +93,10 @@ angular
                 },
                 {
                     name: 'second',
-                    url: 'http://example.net:4444/api'
+                    url: 'http://example.net:4444/api',
+                    headers: {
+                        'Authorization': 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
+                    }
                 }
             ]
         });
@@ -122,7 +127,7 @@ You must provide either `url` or `servers` to configure which backend(s) will be
 
 The argument `url` is a string with the URL of the JSON-RPC server.
 
-The argument `servers` is an array of objects. Each object contains two keys: `name` for the symbolic name of this backend, and `url` for the URL of that JSON-RPC server.
+The argument `servers` is an array of objects. Each object contains three keys: `name` for the symbolic name of this backend, `url` for the URL of that JSON-RPC server, and an optional key `headers` to make the client pass custom header to each request.
 
 The argument `returnHttpPromise` can be used to return a `$http` promise instead of a `$q` promise, if you want to handle the $http errors yourself. See the [Http Promise](#http-promise) section for more information.
 

--- a/example/example-headers.html
+++ b/example/example-headers.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+    <title>angular-jsonrpc-client example 1</title>
+
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.16/angular.js"></script>
+    <script src="../src/angular-jsonrpc-client.js"></script>
+    <script>
+        var url = 'http://localhost:5080/rpc';
+        angular
+            .module('TestApp', ['angular-jsonrpc-client'])
+            .config(function(jsonrpcConfigProvider) {
+                jsonrpcConfigProvider.set({
+                    servers: [{
+                        name: 'main',
+                        url: url,
+                        headers: {
+                            test: 'this is a test header'
+                        }
+                    }],
+                    returnHttpPromise: false
+                });
+            })
+            .controller('TestController', ['$scope', 'jsonrpc', function($scope, jsonrpc) {
+                $scope.url = url;
+                $scope.result = '';
+                $scope.methodCall = 'showHeaders';
+
+                $scope.performCall = function() {
+                    $scope.result = '';
+                    $scope.error = '';
+                    jsonrpc.request($scope.methodCall, {})
+                        .then(function(result) {
+                            $scope.result = result;
+                        })
+                        .catch(function(error) {
+                            $scope.error = error;
+                        });
+                };
+            }]);
+    </script>
+</head>
+<body ng-app="TestApp">
+    <div ng-controller="TestController">
+        <p>Server: <code>{{ url }}</code></p>
+        <p>Sending header: <code>test: This is a test header</code>
+        <p>Method name: <input type="text" ng-model="methodCall">
+            <button ng-click="performCall()">Call now</button></p>
+        <hr>
+        <p ng-show="result">JSON-RPC result:</p>
+        <pre>{{ result }}</pre>
+        <p ng-show="error">JSON-RPC error:</p>
+        <pre>{{ error }}</pre>
+        <p ng-show="error.message === 'Connection refused at http://localhost:5080/rpc'" style="background-color: #ffb0b8;">It looks like the local JSON-RPC server is not running. If this is indeed the case, please start it.</p>
+    </div>
+</body>
+</html>

--- a/example/example-multiple-backends.html
+++ b/example/example-multiple-backends.html
@@ -5,27 +5,27 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.16/angular.js"></script>
     <script src="../src/angular-jsonrpc-client.js"></script>
     <script>
-        var firstBackendUrl = 'http://localhost:5080/rpc';
-        var secondBackendUrl = 'http://localhost:6123/rpc';
+        var firstServerUrl = 'http://localhost:5080/rpc';
+        var secondServerUrl = 'http://localhost:6123/rpc';
         angular
             .module('TestApp', ['angular-jsonrpc-client'])
             .config(function(jsonrpcConfigProvider) {
                 console.info(jsonrpcConfigProvider);
                 jsonrpcConfigProvider.set({
-                    backends: [{
+                    servers: [{
                         name: 'first',
-                        url: firstBackendUrl,
+                        url: firstServerUrl,
                     },
                     {
                         name: 'second',
-                        url: secondBackendUrl,
+                        url: secondServerUrl,
                     }],
                     returnHttpPromise: false
                 });
             })
             .controller('TestController', ['$scope', 'jsonrpc', function($scope, jsonrpc) {
-                $scope.firstBackendUrl = firstBackendUrl;
-                $scope.secondBackendUrl = secondBackendUrl;
+                $scope.firstServerUrl = firstServerUrl;
+                $scope.secondServerUrl = secondServerUrl;
                 $scope.result = '';
                 $scope.methodCall = 'version';
 
@@ -45,8 +45,8 @@
 </head>
 <body ng-app="TestApp">
     <div ng-controller="TestController">
-        <p>First Backend: <code>{{ firstBackendUrl }}</code></p>
-        <p>Second Backend: <code>{{ secondBackendUrl }}</code></p>
+        <p>First Server: <code>{{ firstServerUrl }}</code></p>
+        <p>Second Server: <code>{{ secondServerUrl }}</code></p>
         <p>Method name: <input type="text" ng-model="methodCall">
             <button ng-click="performCall('first')">Call on first backend</button>
             <button ng-click="performCall('second')">Call on second backend</button></p>

--- a/example/jsonrpc.server.js
+++ b/example/jsonrpc.server.js
@@ -6,6 +6,17 @@ var bodyParser       = require('body-parser');
 
 function startFirstServer() {
   var app = express();
+
+  // This is a really crappy way to know what the headers were of a request.
+  // (Un)fortunately, inside the jsonRpcMiddlewareServer methods, we don't
+  // have access to the headers. So we use this crappy method, because it
+  // suffices for this simple test script.
+  var mostRecentHeaders = {};
+  app.use(function(req, res, next) {
+    mostRecentHeaders = req.headers;
+    next();
+  });
+
   app.use(CORSHeaders);
   app.use(bodyParser());
 
@@ -13,6 +24,10 @@ function startFirstServer() {
     version: function(obj, callback) {
       console.info('RPC method "version" called.');
       callback(undefined, { version: '0.42.666' });
+    },
+    showHeaders: function(obj, callback) {
+      console.info('RPC method "showHeaders" called.');
+      callback(undefined, { headers: mostRecentHeaders });
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "keywords": [
     "countries"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "should": "^7.1.1"
+  },
   "devDependencies": {
     "body-parser": "^1.14.1",
     "chai": "^1.10.0",


### PR DESCRIPTION
- Added support for 'headers' in configuration.
  - Headers can be different for each backend.
  - Added example to show how it works.
- Improved test suite significantly.
  - Added tests for new ‘headers’ argument.
  - Made sure that overwriting the ‘Content-Type’ header does not happen.
  - Added more tests for configuration.
  - Start using ‘should’ library in test suite.
