### PR TITLE
Added shortcut for error.data

### DIFF
--- a/spec/angular-jsonrpc-client.spec.js
+++ b/spec/angular-jsonrpc-client.spec.js
@@ -440,7 +440,8 @@ describe('jsonrpc module', function() {
               err.should.eql({
                 name: jsonrpc.ERROR_TYPE_SERVER,
                 message: errorData.error.message,
-                error: errorData.error
+                error: errorData.error,
+                data: errorData.data
               });
               done();
             });

--- a/spec/angular-jsonrpc-client.spec.js
+++ b/spec/angular-jsonrpc-client.spec.js
@@ -441,7 +441,7 @@ describe('jsonrpc module', function() {
                 name: jsonrpc.ERROR_TYPE_SERVER,
                 message: errorData.error.message,
                 error: errorData.error,
-                data: errorData.data
+                data: errorData.error.data
               });
               done();
             });

--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -23,6 +23,7 @@
       this.name    = ERROR_TYPE_SERVER;
       this.message = error.message;
       this.error   = error;
+      this.data    = error.data;
   }
   JsonRpcServerError.prototype = Error.prototype;  
 


### PR DESCRIPTION
`.catch(function(error) {
    $scope.xy = error.error.data;
});`

vs.

`.catch(function(error) {
    $scope.xy = error.data;
});`
