### PR TITLE
Feature/set headers at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ The method `jsonrpc.request()` can be called with either 2 or with 3 arguments:
 
 If it's called with 2 arguments, the serverName is set to `main` internally. This is the same internal name as when you call jsonrpcConfig with the `url` parameter.
 
+# Setting headers at run-time
+
+Sometimes, you don't have the authentication headers during the Angular configuration phase yet, for example because you will only receive them as result of a "log in" JSON-RPC call. It is possible to add headers later on, via `jsonrpc.setExtraHeaders(serverName, headers)`. For example:
+
+```
+jsonrpc.setExtraHeaders('main', {
+    AuthToken: 'my auth token'
+});
+```
+
 # Return value
 
 By default, the return value of `jsonrpc.request` is a `$q` promise, which resolves into the `result` value of the JSON-RPC response. If anything goes wrong with handling the request, the code ends up in `$q.catch()`.

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ If it's called with 2 arguments, the serverName is set to `main` internally. Thi
 
 # Setting headers at run-time
 
-Sometimes, you don't have the authentication headers during the Angular configuration phase yet, for example because you will only receive them as result of a "log in" JSON-RPC call. It is possible to add headers later on, via `jsonrpc.setExtraHeaders(serverName, headers)`. For example:
+Sometimes, you don't have the authentication headers during the Angular configuration phase yet, for example because you will only receive them as result of a "log in" JSON-RPC call. It is possible to add headers later on, via `jsonrpc.setHeaders(serverName, headers)`. For example:
 
 ```
-jsonrpc.setExtraHeaders('main', {
+jsonrpc.setHeaders('main', {
     AuthToken: 'my auth token'
 });
 ```

--- a/example/example-headers.html
+++ b/example/example-headers.html
@@ -32,10 +32,10 @@
                     if ($scope.headerName) {
                         var extraHeaders = {};
                         extraHeaders[$scope.headerName] = $scope.headerValue;
-                        jsonrpc.setExtraHeaders('main', extraHeaders);
+                        jsonrpc.setHeaders('main', extraHeaders);
                     }
                     else {
-                        jsonrpc.setExtraHeaders('main', {});
+                        jsonrpc.setHeaders('main', {});
                     }
 
                     jsonrpc.request($scope.methodCall, {})

--- a/example/example-headers.html
+++ b/example/example-headers.html
@@ -28,6 +28,16 @@
                 $scope.performCall = function() {
                     $scope.result = '';
                     $scope.error = '';
+
+                    if ($scope.headerName) {
+                        var extraHeaders = {};
+                        extraHeaders[$scope.headerName] = $scope.headerValue;
+                        jsonrpc.setExtraHeaders('main', extraHeaders);
+                    }
+                    else {
+                        jsonrpc.setExtraHeaders('main', {});
+                    }
+
                     jsonrpc.request($scope.methodCall, {})
                         .then(function(result) {
                             $scope.result = result;
@@ -43,6 +53,7 @@
     <div ng-controller="TestController">
         <p>Server: <code>{{ url }}</code></p>
         <p>Sending header: <code>test: This is a test header</code>
+        <p>Extra custom header - name: <input type="text" ng-model="headerName"> value: <input type="text" ng-model="headerValue"></p>
         <p>Method name: <input type="text" ng-model="methodCall">
             <button ng-click="performCall()">Call now</button></p>
         <hr>

--- a/spec/angular-jsonrpc-client.spec.js
+++ b/spec/angular-jsonrpc-client.spec.js
@@ -327,7 +327,7 @@ describe('jsonrpc module', function() {
       });
     });
 
-    describe('jsonrpc.request with extra headers via setExtraHeaders', function() {
+    describe('jsonrpc.request with extra headers via setHeaders', function() {
       var extraHeaders = {
         test: 'four five six'
       }
@@ -359,7 +359,7 @@ describe('jsonrpc module', function() {
             })
             .respond(httpData.returnValue);
 
-          jsonrpc.setExtraHeaders('main', extraHeaders);
+          jsonrpc.setHeaders('main', extraHeaders);
 
           jsonrpc.request(methodName, args)
             .then(function(data) {

--- a/spec/angular-jsonrpc-client.spec.js
+++ b/spec/angular-jsonrpc-client.spec.js
@@ -279,7 +279,7 @@ describe('jsonrpc module', function() {
       });
     });
 
-    describe('jsonrpc.request with extra headers', function() {
+    describe('jsonrpc.request with extra headers via config', function() {
       var configuredHeaders = {
         test: 'one two three'
       }
@@ -310,6 +310,56 @@ describe('jsonrpc module', function() {
               return headers.test === configuredHeaders.test
             })
             .respond(httpData.returnValue);
+
+          jsonrpc.request(methodName, args)
+            .then(function(data) {
+              data.should.eql({ version: '1.7.9' });
+              done();
+            })
+            .catch(function(err) {
+              // should not come here
+              console.error(err);
+              done(err);
+            });
+
+          $httpBackend.flush();
+        });
+      });
+    });
+
+    describe('jsonrpc.request with extra headers via setExtraHeaders', function() {
+      var extraHeaders = {
+        test: 'four five six'
+      }
+      var mockConfig = {
+        servers: [{
+          name: 'main',
+          url: url,
+          headers: [],
+        }],
+        returnHttpPromise: false
+      };
+
+      beforeEach(function () {
+          module(function ($provide) {
+              $provide.value('jsonrpcConfig', mockConfig);
+          });
+      });
+
+      it('should perform a jsonrpc call with extra headers', function(done) {
+        inject(function(jsonrpc, $injector, $http) {
+          var id = getNextId();
+          var httpData = _getHttpData(id);
+          var $httpBackend = $injector.get('$httpBackend');
+          var jsonrpcRequestHandler = $httpBackend.expect(
+            httpData.expected.method,
+            httpData.expected.url,
+            httpData.expected.body, function(headers) {
+              return headers.test === extraHeaders.test
+            })
+            .respond(httpData.returnValue);
+
+          jsonrpc.setExtraHeaders('main', extraHeaders);
 
           jsonrpc.request(methodName, args)
             .then(function(data) {

--- a/src/angular-jsonrpc-client.js
+++ b/src/angular-jsonrpc-client.js
@@ -42,7 +42,7 @@
     
     return {
       request              : request,
-      setExtraHeaders      : setExtraHeaders,
+      setHeaders           : setHeaders,
       ERROR_TYPE_SERVER    : ERROR_TYPE_SERVER,
       ERROR_TYPE_TRANSPORT : ERROR_TYPE_TRANSPORT,
       ERROR_TYPE_CONFIG    : ERROR_TYPE_CONFIG,
@@ -130,7 +130,7 @@
       };
     }
 
-    function setExtraHeaders(serverName, headers) {
+    function setHeaders(serverName, headers) {
       var server = _findServer(serverName);
 
       extraHeaders[server.name] = headers;


### PR DESCRIPTION
- Added new method `jsonrpc.setHeaders(serverName, headers)` to set headers at runtime.
- These headers are added on top of the extra headers from the configuration phase.
- These headers will overwrite, if present, headers with the same name from the configuration phase.
